### PR TITLE
(fix) missing header at /api/v1/status

### DIFF
--- a/api/v1/views/index.py
+++ b/api/v1/views/index.py
@@ -3,6 +3,7 @@
 Defines the index for V1 API.
 """
 import json
+from flask import Response
 from api.v1.views import app_views
 
 
@@ -11,4 +12,5 @@ def status():
     """
     Returns OK
     """
-    return json.dumps({'status': "OK"}, indent=2)
+    return Response(json.dumps({'status': "OK"}, indent=2),
+                    mimetype='application/json')


### PR DESCRIPTION
Added correct Content-Type header to the response of /api/v1/status.